### PR TITLE
Added readEncoding and writeEncoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ Default value: `false`
 
 A boolean flag which makes js-yaml to throw errors instead of warnings.
 
+#### options.readEncoding
+Type: `String`
+Default value: `grunt.file.defaultEncoding`
+
+An override to the default buffer encoding used to read in the YAML file (`grunt.file.read`).
+
+#### options.writeEncoding
+Type: `String`
+Default value: `grunt.file.defaultEncoding`
+
+An override to the default buffer encoding used to write out the JSON file (`grunt.file.write`).
+
 ### Usage Examples
 
 See [my repository](https://github.com/shiwano/cw-schema).

--- a/tasks/yaml.js
+++ b/tasks/yaml.js
@@ -64,8 +64,16 @@ module.exports = function(grunt) {
       space: 2,
       middleware: function() {},
       disableDest: false,
-      strict: false
+      strict: false,
+      readEncoding: grunt.file.defaultEncoding,
+      writeEncoding: grunt.file.defaultEncoding
     });
+    var readOptions = {
+            encoding: options.readEncoding
+    }
+    var writeOptions = {
+            encoding: options.writeEncoding
+    }
 
     yamlSchema = createYamlSchema(options.customTypes);
     strictOption = options.strict;
@@ -77,7 +85,7 @@ module.exports = function(grunt) {
         }
 
         var dest = filePair.dest.replace(/\.ya?ml$/, '.json');
-        var result = loadYaml(src);
+        var result = loadYaml(src, readOptions);
         var json = JSON.stringify(result, null, options.space);
 
         if (_.isFunction(options.middleware)) {
@@ -85,7 +93,7 @@ module.exports = function(grunt) {
         }
 
         if (!options.disableDest) {
-          grunt.file.write(dest, json);
+          grunt.file.write(dest, json, writeOptions);
           grunt.log.writeln('Compiled ' + src.cyan + ' -> ' + dest.cyan);
         }
       });


### PR DESCRIPTION
When working with files that do not match the
`grunt.file.defaultEncoding` setting, it was not possible to get all
of the information from the file. For example; when the default
encoding is set to `utf8` you couldn't read in accented characters
from a file with a different encoding.

With this change encodings for both file read and file write can be
specified in the `options` object so that task can read files
appropriately and write them out as the user wishes.

For my use case I was losing French accented characters from my YAML
files. The solution was to read them in using the `latin1` encoding
(Grunt supports `latin1` through the use of `iconv-lite`). Once the
file content was read it can happily be written back out as JSON in
`utf8`, which was my default encoding.

Summary:
- Able to read in YAML and write out JSON with different encodings
- Both options default to `grunt.file.defaultEncoding`
- Update README.md with documentation for the options
